### PR TITLE
Introduce ALGOL 60 comments style

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [[http://keepachangelog.com][Keep a Changelog]] and this project adheres to [[http://semver.org][Semantic Versioning]].
 
 ** [[https://github.com/sergeyklay/bnf-mode/compare/0.4.1...HEAD][Unreleased]]
+*** Added
+- Introduce ALGOL 60 comments style [[https://github.com/sergeyklay/bnf-mode/pull/4][#4]]
+
+*** Changed
+- Only setting =bnf-mode-algol-comments-style= to non-nil will allow use
+  semicolons as a regular terminal symbols
+
 ** [[https://github.com/sergeyklay/bnf-mode/compare/0.4.0...0.4.1][0.4.1]] - 2019-04-21
 *** Fixes
 - Minor fix related to build & deploy BNF Mode on Travis CI
@@ -21,7 +28,7 @@ The format is based on [[http://keepachangelog.com][Keep a Changelog]] and this 
 
 ** [[https://github.com/sergeyklay/bnf-mode/compare/0.3.1...0.3.2][0.3.2]] - 2019-03-24
 *** Changed
-- Publish package on MELPA [[https://github.com/melpa/melpa/pull/6074][(melpa/melpa#6074)]]
+- Published package on MELPA [[https://github.com/melpa/melpa/pull/6074][(melpa/melpa#6074)]]
 
 *** Fixed
 - In the BNF there are no strings thus treat ' and " as a regular symbols
@@ -29,7 +36,7 @@ The format is based on [[http://keepachangelog.com][Keep a Changelog]] and this 
 - In the BNF there are no grouping brackets except angle ones. Fixed
 
 *** Removed
-- Removing the ~bnf-mode-version~ function. Users can easily call ~describe-package~
+- Removed the ~bnf-mode-version~ function. Users can easily call ~describe-package~
   or ~pkg-info-package-version~ interactively if they want to get this information [[https://github.com/sergeyklay/bnf-mode/issues/1][(#1)]]
 
 ** [[https://github.com/sergeyklay/bnf-mode/compare/0.3.0...0.3.1][0.3.1]] - 2019-03-17

--- a/bnf-mode.el
+++ b/bnf-mode.el
@@ -234,11 +234,10 @@ Currently handled:
 
 (defconst bnf--bnf-syntax-propertize-macro
   (syntax-propertize-rules
-   ("\\(?:begin\\_>\\|;\\)\\(?:$\\|\\s-\\|\n\\)+\\(\\(?:comment\\_>\\)[^;]*;\\)"
-    (1 "<")))
+   ("\\(?:begin\\s-+\\|;\\s-*\\)\\(comment\\)\\(;\\|\\s-+[^;]*;\\)" (1 "<")))
   "Fontify comments in ALGOL 60 style.
 Provide a macro to apply syntax table properties to comments in ALGOL 60 style.
-Will used only if `bnf-mode-algol-commets-style' is set to t")
+Will be used only if `bnf-mode-algol-commets-style' is set to t")
 
 ;;;###autoload
 (define-derived-mode bnf-mode prog-mode "BNF"
@@ -252,7 +251,7 @@ Will used only if `bnf-mode-algol-commets-style' is set to t")
       (progn
         (setq-local comment-start "; comment ")
         (setq-local comment-end ";")
-        (setq-local comment-start-skip "\\(?:\\(\\W\\|^\\)comment\\_>\\)\\s-+")
+        (setq-local comment-start-skip "\\(?:\\(\\W\\|^\\)comment\\)\\s-+")
         (setq-local syntax-propertize-function
                     bnf--bnf-syntax-propertize-macro))
     (progn

--- a/bnf-mode.el
+++ b/bnf-mode.el
@@ -84,6 +84,23 @@
   :type 'hook
   :group 'bnf)
 
+(defcustom bnf-mode-algol-commets-style nil
+  "Non-nil means use for BNF comments style introduced in ALGOL 60.
+
+For the purpose of including text among the symbols of a program the following
+\"comment\" conventions will hold:
+
+  :------------------------------------------------:------------------:
+  | The sequence of basic symbols:                 | is equivalent to |
+  :------------------------------------------------:------------------:
+  | ; comment <any sequence not containing ;>;     | ;                |
+  | begin comment <any sequence not containing ;>; | begin            |
+  :------------------------------------------------:------------------:
+
+Note: Enabling this feature disables ABNF/EBN comments style (just \";\")."
+  :group 'bnf
+  :type 'boolean)
+
 
 ;;; Specialized rx
 
@@ -160,33 +177,43 @@ See `rx' documentation for more information about REGEXPS param."
   (let ((table (make-syntax-table)))
     ;; Give CR the same syntax as newline
     (modify-syntax-entry ?\^m "> b" table)
-    ;; Comments setup
-    (modify-syntax-entry ?\;  "<"   table)
-    (modify-syntax-entry ?\n  ">"   table)
+
     ;; Treat ::= as sequence of symbols
-    (modify-syntax-entry ?\:  "_"   table)
-    (modify-syntax-entry ?\=  "_"   table)
+    (modify-syntax-entry ?\: "_" table)
+    (modify-syntax-entry ?\= "_" table)
+
     ;; Treat | as a symbol
-    (modify-syntax-entry ?\|  "_"   table)
+    (modify-syntax-entry ?\| "_" table)
+
     ;; In BNF there are no strings
     ;; so treat ' and " as a symbols
-    (modify-syntax-entry ?\"  "_"  table)
-    (modify-syntax-entry ?\'  "_"  table)
+    (modify-syntax-entry ?\" "_" table)
+    (modify-syntax-entry ?\' "_" table)
+
     ;; In BNF there are no grouping
     ;; brackets except angle ones
-    (modify-syntax-entry ?\(  "_"  table)
-    (modify-syntax-entry ?\)  "_"  table)
-    (modify-syntax-entry ?\{  "_"  table)
-    (modify-syntax-entry ?\}  "_"  table)
-    (modify-syntax-entry ?\[  "_"  table)
-    (modify-syntax-entry ?\]  "_"  table)
+    (modify-syntax-entry ?\( "_" table)
+    (modify-syntax-entry ?\) "_" table)
+    (modify-syntax-entry ?\{ "_" table)
+    (modify-syntax-entry ?\} "_" table)
+    (modify-syntax-entry ?\[ "_" table)
+    (modify-syntax-entry ?\] "_" table)
+
     ;; Group angle brackets
-    (modify-syntax-entry ?\<  "(>"  table)
-    (modify-syntax-entry ?\>  ")<"  table)
+    (modify-syntax-entry ?\< "(>" table)
+    (modify-syntax-entry ?\> ")<" table)
+
+    ;; Comments setup
+    (if bnf-mode-algol-commets-style
+        (modify-syntax-entry ?\; ">" table)
+      (progn
+        (modify-syntax-entry ?\; "<" table)
+        (modify-syntax-entry ?\n ">" table)))
+
     table)
   "Syntax table in use in `bnf-mode' buffers.")
 
-(defun bnf--syntax-propertize (start end)
+(defun bnf--bnf-syntax-propertize-function (start end)
   "Apply syntax table properties to special constructs in region START to END.
 Currently handled:
 
@@ -205,18 +232,52 @@ Currently handled:
 
 ;;; Initialization
 
+(defconst bnf--bnf-syntax-propertize-macro
+  (syntax-propertize-rules
+   ("\\(?:begin\\_>\\|;\\)\\(?:$\\|\\s-\\|\n\\)+\\(\\(?:comment\\_>\\)[^;]*;\\)"
+    (1 "<")))
+  "Fontify comments in ALGOL 60 style.
+Provide a macro to apply syntax table properties to comments in ALGOL 60 style.
+Will used only if `bnf-mode-algol-commets-style' is set to t")
+
 ;;;###autoload
 (define-derived-mode bnf-mode prog-mode "BNF"
   "A major mode for editing BNF grammars."
   :syntax-table bnf-mode-syntax-table
   :group 'bnf-mode
-  ;; Comments setup.
+
+  ;; Comments setup
   (setq-local comment-use-syntax nil)
-  (setq-local comment-start "; ")
-  (setq-local comment-end "")
-  (setq-local comment-start-skip "\\(?:\\(\\W\\|^\\);+\\)\\s-*")
-  ;; Tune up syntax `syntax-table'
-  (setq-local syntax-propertize-function #'bnf--syntax-propertize)
+  (if bnf-mode-algol-commets-style
+      (progn
+        (setq-local comment-start "; comment ")
+        (setq-local comment-end ";")
+        (setq-local comment-start-skip "\\(?:\\(\\W\\|^\\)comment\\_>\\)\\s-+")
+        (setq-local syntax-propertize-function
+                    bnf--bnf-syntax-propertize-macro))
+    (progn
+      (setq-local comment-start "; ")
+      (setq-local comment-end "")
+      (setq-local comment-start-skip "\\(?:\\(\\W\\|^\\);+\\)\\s-+")
+      (setq-local syntax-propertize-function
+                  #'bnf--bnf-syntax-propertize-function)))
+
+  ;; Basically `syntax-propertize-function' is a construct which belongs
+  ;; to `font-lock'.  But correct indentation depends on
+  ;; syntax properties of the text, and that should ideally be
+  ;; independent of font-lock being activated or not.
+  ;;
+  ;; For `bnf-mode', this means that with `font-lock' disabled, we wont
+  ;; have our syntax properties set correctly, and indentation will
+  ;; suffer.
+  ;;
+  ;; To patch our way around this, we issue a `syntax-propertize' call
+  ;; manually, `font-lock' enabled or not.
+  (with-silent-modifications
+    (if bnf-mode-algol-commets-style
+        (funcall syntax-propertize-function (point-min) (point-max))
+      (bnf--bnf-syntax-propertize-function (point-min) (point-max))))
+
   ;; Font locking
   (setq font-lock-defaults
         '(

--- a/test/bnf-mode-font-test.el
+++ b/test/bnf-mode-font-test.el
@@ -45,8 +45,9 @@
    (should-not (bnf-test-face-at 31))
    (should-not (bnf-test-face-at 35))))
 
-(ert-deftest bnf-mode-syntax-table/fontify-line-comment ()
+(ert-deftest bnf-mode-syntax-table/fontify-line-comments ()
   :tags '(fontification syntax-table)
+  (custom-set-variables '(bnf-mode-algol-comments-style nil))
   (bnf-test-with-temp-buffer
    "; A
 
@@ -55,6 +56,12 @@
    (should (eq (bnf-test-face-at 3) 'font-lock-comment-face))
    (should-not (bnf-test-face-at 5))
    (should (eq (bnf-test-face-at 24) 'font-lock-comment-face))))
+
+;; TODO
+(ert-deftest bnf-mode-syntax-table/fontify-algol-comments ()
+  :tags '(fontification syntax-table)
+  (custom-set-variables '(bnf-mode-algol-comments-style t))
+  (bnf-test-with-temp-buffer "" ))
 
 (ert-deftest bnf-mode-syntax-table/fontify-nonterminals ()
   :tags '(fontification syntax-table)
@@ -162,24 +169,6 @@ angle-brackets ::= are-optional"
    ;; "empty"
    (should (eq (bnf-test-face-at 90) 'font-lock-builtin-face))
    (should (eq (bnf-test-face-at 94) 'font-lock-builtin-face))))
-
-(ert-deftest bnf-mode-syntax-table/fontify-dotcomma-inside-rule ()
-  :tags '(fontification syntax-table)
-  (bnf-test-with-temp-buffer
-   "<a rule> ::= <abc;>
-; <foo> ::= <bar>
-<a> ::= <ab;c>"
-   ;; "abc;"
-   (should (eq (bnf-test-face-at 16) 'font-lock-builtin-face))
-   (should (eq (bnf-test-face-at 18) 'font-lock-builtin-face))
-   ;; "; <foo> ::= <bar>"
-   (should (eq (bnf-test-face-at 22) 'font-lock-comment-delimiter-face))
-   (should (eq (bnf-test-face-at 22) 'font-lock-comment-delimiter-face))
-   (should (eq (bnf-test-face-at 23) 'font-lock-comment-face))
-   (should (eq (bnf-test-face-at 37) 'font-lock-comment-face))
-   ;; "ab;c"
-   (should (eq (bnf-test-face-at 48) 'font-lock-builtin-face))
-   (should (eq (bnf-test-face-at 51) 'font-lock-builtin-face))))
 
 (provide 'bnf-mode-font-test)
 ;;; bnf-mode-font-test.el ends here

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -57,6 +57,7 @@
      ,(if (fboundp 'font-lock-ensure)
           '(font-lock-ensure)
         '(with-no-warnings (font-lock-fontify-buffer)))
+
      (goto-char (point-min))
      ,@body))
 


### PR DESCRIPTION
Setting **`bnf-mode-algol-comments-style`** to non-nill means use for BNF comments style introduced in ALGOL 60.


For the purpose of including text among the symbols of a program the following "comment" conventions will hold:

| The sequence of basic symbols  | Is equivalent to |
| :---         |     :---      |
| **`; comment`** `<any sequence not containing ;>`**`;`**  | **` ; `**  |
| **`begin comment`** `<any sequence not containing ;>`**` ; `**  | **`begin`**  |

Note: Enabling this feature will disable comments recognition which use semicolon only (**` ; `**).
