### PR TITLE
Add GNU ELPA badge to README.org

### DIFF
--- a/README.org
+++ b/README.org
@@ -2,6 +2,7 @@
 
 [[https://www.gnu.org/licenses/gpl-3.0.txt][https://img.shields.io/badge/license-GPL_3-green.svg]]
 [[https://github.com/sergeyklay/bnf-mode/actions][https://github.com/sergeyklay/bnf-mode/workflows/build/badge.svg]]
+[[https://elpa.gnu.org/packages/bnf-mode.html][https://elpa.gnu.org/packages/bnf-mode.svg]]
 [[https://melpa.org/#/bnf-mode][https://melpa.org/packages/bnf-mode-badge.svg]]
 [[https://stable.melpa.org/#/bnf-mode][https://stable.melpa.org/packages/bnf-mode-badge.svg]]
 


### PR DESCRIPTION
This adds a GNU ELPA badge to README.org.

You can see it here:
https://elpa.gnu.org/packages/bnf-mode.svg

Thanks!